### PR TITLE
demo: enable AI security triage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
     - cron: '30 0 * * 1'
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   security-events: write
   pull-requests: write
@@ -18,6 +18,7 @@ jobs:
   security:
     name: Security CI
     uses: steel-mountain-ng/security-workflows/.github/workflows/reusable-security-ci.yml@v1
+    secrets: inherit
     with:
       fail-severity: HIGH
       upload-sarif: true
@@ -25,3 +26,7 @@ jobs:
       dockerfile: Dockerfile
       context: .
       image-name: local/vulnerable-app:ci
+      run-ai-triage: true
+      ai-model: openai/gpt-4o-mini
+      ai-max-findings: '25'
+      ai-open-fix-prs: true

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Sample findings planted for demos:
 
 The orchestrator ends with a **Security Gate** job. This app is intentionally vulnerable, so the gate is expected to fail — that is the demo.
 
+On pull requests, **AI triage** (OpenRouter) posts an advisory sticky comment with TP/FP, exploitability, and reachability notes, and may open draft fix PRs for allowlisted items. Set repo secret `OPENROUTER_API_KEY` for full LLM triage; without it, heuristic triage still comments. AI never overrides the Security Gate.
+
+
 ## Setup
 1. Clone the repository
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- Enable advisory AI triage (OpenRouter) on Security CI for pull requests
- Allowlisted draft fix PRs enabled for demo
- Security Gate remains the merge authority

## Test plan
- [ ] Security workflow runs scanners + Security Gate
- [ ] AI Triage job posts sticky PR comment
- [ ] With OPENROUTER_API_KEY set, comment includes model triage; without it, heuristic fallback still comments