### PR TITLE
fix(security): run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ENV AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
     NODE_ENV=production
 
 # Run as root (bad practice) — USER intentionally omitted
-USER root
-
+USER appuser
 # Start with a vulnerable command
 CMD ["npm", "start"] 


### PR DESCRIPTION
Draft fix proposed by security-workflows alert manager (advisory).

- Finding: `DS-0002`
- Fix type: `dockerfile_user_root`

Security Gate remains authoritative. Review carefully before merging.

Made with [Cursor](https://cursor.com)